### PR TITLE
Default value for private network IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ var server = http.createServer(function(req, res) {
 ```javascript
 var requestCountry = require('request-country');
 app.use(requestCountry.middleware({
-  attributeName: 'requestCountryCode'
-  // default attributeName is 'requestCountryCode'
+  attributeName: 'requestCountryCode', // default is 'requestCountryCode'
+  privateIpCountry: 'US'
 }));
 
 app.use(function(req, res) {

--- a/README.md
+++ b/README.md
@@ -20,13 +20,19 @@ var server = http.createServer(function(req, res) {
 });
 ```
 
+If you want to set default value for [private network](https://en.wikipedia.org/wiki/Private_network) IPs, you can pass second argument. So if you open your site from private network or localhost it will be returned.
+
+```javascript
+  requestCountry(req, 'US');
+```
+
 ### As Connect Middleware
 
 ```javascript
 var requestCountry = require('request-country');
 app.use(requestCountry.middleware({
   attributeName: 'requestCountryCode', // default is 'requestCountryCode'
-  privateIpCountry: 'US'
+  privateIpCountry: 'US' // Result for private network IPs
 }));
 
 app.use(function(req, res) {

--- a/index.js
+++ b/index.js
@@ -1,15 +1,27 @@
 var getClientIp = require('request-ip').getClientIp;
 var getGeo = require('geoip-country').lookup;
 
-function requestCountry(req) {
-	var geo = getGeo(getClientIp(req));
-	return (geo && geo.country) || false;
+function isPrivateNetwork(ip) {
+	//0.0.0.0 - 10.255.255.255, 172.16.0.0 - 172.31.255.255, 192.168.0.0 - 192.168.255.255, 127.0.0.1
+	const privateIpRegexp = /(192\.168\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[0-2])\.[0-9]+\.[0-9]+|127\.0\.0\.1)/;
+	return privateIpRegexp.test(ip);
+}
+
+function requestCountry(req, privateIpCountry) {
+	var ip = getClientIp(req);
+	if (privateIpCountry && isPrivateNetwork(ip)) {
+		return privateIpCountry;
+	} else {
+		var geo = getGeo();
+		return (geo && geo.country) || false;
+	}
 }
 
 requestCountry.middleware = function(options){
 	var attr = options && options.attributeName || 'requestCountryCode';
+	var privateIpCountry = options && options.privateIpCountry || false;
 	return function(req, res, next) {
-		req[attr] = requestCountry(req);
+		req[attr] = requestCountry(req, privateIpCountry);
 		next();
 	}
 };


### PR DESCRIPTION
If you want to set default value for [private network](https://en.wikipedia.org/wiki/Private_network) IPs, you can pass second argument. So if you open your site from private network or localhost it will be returned.